### PR TITLE
remove quotes from $@

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,9 +57,9 @@ add this to your `.bash_profile`/`.bashrc`
 # originally from https://gist.github.com/mafintosh/405048d304fbabb830b2
 npm () {
   if [ "$1" = "publish" ]; then
-    dependency-check . &&  $(which npm) "$@"
+    dependency-check . &&  $(which npm) $@
   else
-    $(which npm) "$@"
+    $(which npm) $@
   fi
 }
 ```


### PR DESCRIPTION
I'm pretty sure this shouldn't work on any version of bash, the quotes will combine all original arguments into a single argument
