### PR TITLE
Allows builtins[0] (assert) to be recognized as core.

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ function parse(opts, cb) {
       var requires = detective(contents)
       var relatives = []
       requires.map(function(req) {
-        var isCore = builtins.indexOf(req) > 0
+        var isCore = builtins.indexOf(req) > -1
         if (IS_NOT_RELATIVE.test(req) && !isCore) {
           // require('foo/bar') -> require('foo')
           if (req.indexOf('/') > -1) req = req.split('/')[0]


### PR DESCRIPTION
I found a bug where the assert module wasn't being recognized as a core module.
