### PR TITLE
Expose as a Grunt task + enable ignoring of extra devDependencies

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -19,7 +19,7 @@ check({path: args._[0], entries: args.entry}, function(err, data) {
   var deps = data.used
   var results, errMsg, successMsg
   if (args.unused || args.extra) {
-    results = check.extra(pkg, deps)
+    results = check.extra(pkg, deps, {excludeDev: args.dev === false})
     errMsg = 'Fail! Modules in package.json not used in code: '
     successMsg = 'Success! All dependencies in package.json are used in the code'
   } else {

--- a/index.js
+++ b/index.js
@@ -32,14 +32,20 @@ module.exports.missing = function(pkg, deps) {
   return missing
 }
 
-module.exports.extra = function(pkg, deps) {
+module.exports.extra = function(pkg, deps, options) {
+  options = options || {}
+  
   var missing = []
-  var allDeps = Object.keys(pkg.dependencies || {}).concat(Object.keys(pkg.devDependencies || {}))
+  var allDeps = Object.keys(pkg.dependencies || {})
+  
+  if (!options.excludeDev) {
+    allDeps = allDeps.concat(Object.keys(pkg.devDependencies || {}))
+  }
   
   allDeps.map(function(dep) {
     if (deps.indexOf(dep) === -1) missing.push(dep)
   })
-
+  
   return missing
 }
 

--- a/index.js
+++ b/index.js
@@ -71,7 +71,10 @@ function parse(opts, cb) {
   if (opts.entries) {
     if (typeof opts.entries === 'string') opts.entries = [opts.entries]
     opts.entries.forEach(function(entry) {
-      paths.push(path.resolve(path.join(path.dirname(pkgPath), entry)))
+      entry = path.resolve(path.join(path.dirname(pkgPath), entry))
+      if (paths.indexOf(entry) === -1) {
+        paths.push(entry)
+      }
     })
   }
   

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,10 @@ running `dependency-check ./package.json` will check to make sure that all modul
 
 running `dependency-check ./package.json --unused` will do the inverse of the default missing check and will tell you which modules in your package.json dependencies **were not used** in your code. An alias for `--unused` is `--extra`
 
+### --no-dev
+
+running `dependency-check ./package.json --unused --no-dev` won't tell you about which devDependencies in your package.json dependencies that were not used in your code. Only usable with `--unused`
+
 ### --entry
 
 by default your `main` and `bin` entries from package.json will be parsed, but you can add more the list of entries by passing them in as `--entry`, e.g.:

--- a/tasks/dependency-check.js
+++ b/tasks/dependency-check.js
@@ -7,6 +7,7 @@ module.exports = function (grunt) {
     var options = this.options({
       missing: true,
       unused: true,
+      excludeMissingDev: false,
       package: '.'
     })
 
@@ -20,7 +21,7 @@ module.exports = function (grunt) {
       var results
 
       if (options.unused) {
-        results = check.extra(pkg, deps)
+        results = check.extra(pkg, deps, {excludeDev: options.excludeMissingDev})
         if (results.length !== 0) {
           grunt.log.error('Modules in package.json not used in code: ' + grunt.log.wordlist(results, {color: 'red'}))
         }

--- a/tasks/dependency-check.js
+++ b/tasks/dependency-check.js
@@ -1,0 +1,39 @@
+module.exports = function (grunt) {
+  var check = require('../')
+
+  grunt.registerMultiTask('dependency-check', 'Matches used modules to listed dependencies', function () {
+    var done = this.async()
+
+    var options = this.options({
+      missing: true,
+      unused: true,
+      package: '.'
+    })
+
+    check({path: options.package, entries: this.filesSrc}, function(err, data) {
+      if (err) {
+        return grunt.fail.fatal(err)
+      }
+
+      var pkg = data.package
+      var deps = data.used
+      var results
+
+      if (options.unused) {
+        results = check.extra(pkg, deps)
+        if (results.length !== 0) {
+          grunt.log.error('Modules in package.json not used in code: ' + grunt.log.wordlist(results, {color: 'red'}))
+        }
+      }
+
+      if (options.missing) {
+        results = check.missing(pkg, deps)
+        if (results.length !== 0) {
+          grunt.fail.fatal('Dependencies not listed in package.json: ' + grunt.log.wordlist(results, {color: 'red'}))
+        }
+      }
+
+      done()
+    })
+  })
+}


### PR DESCRIPTION
Excellent module this! Checking for missing and extra modules is a great addition to the standard lint-checks etc of a project.

I wrapped the CLI interface up as a Grunt task for our internal lint/testing module at @bloglovin, https://github.com/bloglovin/lintlovin/pull/3, and I wanted to contribute it back upstream and since its just a simple little file living in a `tasks/` folder I thought you might want to include it even though you yourself don't use it. If so I can do a follow up PR that adds some documentation to the README about it.

In addition to the Grunt task there's two other additions in here that should ideally be separate PR:s and I can submit them as such if you want to merge then separately, but as the Grunt task is somewhat dependent on them I decided to include them here anyway.

All in all this PR includes:

* A fix that ensures that duplicate `--entry` files and/or an `--entry` that matches the `main` or `bin` file won't result in a file being checked twice
* A new `--no-dev` option for the CLI tool that's used together with `--extra`/`--unused` to ignore any seemingly unused devDependencies, such as most Grunt modules and modules like [husky](https://www.npmjs.com/package/husky)
* A Grunt task
* An extension of the Grunt task to expose the `--no-dev` option. This is very useful for me in the `lintlovin` project as it makes all our Bloglovin node-projects use [husky](https://www.npmjs.com/package/husky), which is a devDependency you never `require()`