### PR TITLE
Added support for scoped modules, fixes #21

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,8 @@ function parse(opts, cb) {
         var isCore = builtins.indexOf(req) > -1
         if (IS_NOT_RELATIVE.test(req) && !isCore) {
           // require('foo/bar') -> require('foo')
-          if (req.indexOf('/') > -1) req = req.split('/')[0]
+          if (req[0] !== '@' && req.indexOf('/') > -1) req = req.split('/')[0]
+          else if (req[0] === '@') req = req.split('/').slice(0, 2).join('/')
           debug('require("' + req + '")' + ' is a dependency')
           deps[req] = true
         } else {

--- a/test/foo.js
+++ b/test/foo.js
@@ -3,3 +3,4 @@ require('async')
 
 require('./pizza')
 require('./donkey')
+require('./scoped')

--- a/test/package.json
+++ b/test/package.json
@@ -4,6 +4,8 @@
   "dependencies": {
     "async": "*",
     "resolve": "*",
-    "minimist": "*"
+    "minimist": "*",
+    "@scope/test1": "*",
+    "@scope/test2": "*"
   }
 }

--- a/test/scoped.js
+++ b/test/scoped.js
@@ -1,0 +1,2 @@
+require('@scope/test1')
+require('@scope/test2/something')


### PR DESCRIPTION
This adds support for [scoped modules](https://docs.npmjs.com/misc/scope), which are used in private NPM registries such as NPM Enterprise.