### PR TITLE
Add option to ignore specific unused modules

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -16,7 +16,10 @@ if (args.help || args._.length === 0) {
   console.log('--missing (default)   Check to make sure that all modules in your code are listed in your package.json')
   console.log('--unused, --extra     The inverse of the --missing check and will tell you which modules in your package.json *were not* used in your code')
   console.log('--no-dev              Won\'t tell you about which devDependencies in your package.json dependencies that were not used in your code. Only usable with --unused')
+  console.log('--ignore-module, -i   Won\'t tell you about module names passed in as --ignore-module / -i. Only usable with --unused')
   console.log('--entry               By default your main and bin entries from package.json will be parsed, but you can add more the list of entries by passing them in as --entry')
+  console.log('--version             Show current version')
+  console.log('--ignore              To always exit with code 0 pass --ignore')
   console.log("")
 
   process.exit(1)
@@ -31,7 +34,10 @@ check({path: args._[0], entries: args.entry}, function(err, data) {
   var deps = data.used
   var results, errMsg, successMsg
   if (args.unused || args.extra) {
-    results = check.extra(pkg, deps, {excludeDev: args.dev === false})
+    results = check.extra(pkg, deps, {
+      excludeDev: args.dev === false,
+      ignore: [].concat(args['ignore-module'] || [], args.i || [])
+    })
     errMsg = 'Fail! Modules in package.json not used in code: '
     successMsg = 'Success! All dependencies in package.json are used in the code'
   } else {

--- a/index.js
+++ b/index.js
@@ -37,13 +37,16 @@ module.exports.extra = function(pkg, deps, options) {
   
   var missing = []
   var allDeps = Object.keys(pkg.dependencies || {})
+  var ignore = options.ignore || [];
+  
+  if (typeof ignore === 'string') ignore = [ignore]
   
   if (!options.excludeDev) {
     allDeps = allDeps.concat(Object.keys(pkg.devDependencies || {}))
   }
   
   allDeps.map(function(dep) {
-    if (deps.indexOf(dep) === -1) missing.push(dep)
+    if (deps.indexOf(dep) === -1 && ignore.indexOf(dep) === -1) missing.push(dep)
   })
   
   return missing

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,10 @@ dependency-check package.json --entry tests.js
 
 in the above example `tests.js` will get added to the entries that get parsed + checked in addition to the defaults. You can specify as many separate `--entry` arguments as you want
 
+### --help
+
+shows above options and all other available options
+
 ## auto check before every npm publish
 
 add this to your `.bash_profile`/`.bashrc`

--- a/tasks/dependency-check.js
+++ b/tasks/dependency-check.js
@@ -7,7 +7,8 @@ module.exports = function (grunt) {
     var options = this.options({
       missing: true,
       unused: true,
-      excludeMissingDev: false,
+      excludeUnusedDev: false,
+      ignoreUnused: [],
       package: '.'
     })
 
@@ -21,7 +22,10 @@ module.exports = function (grunt) {
       var results
 
       if (options.unused) {
-        results = check.extra(pkg, deps, {excludeDev: options.excludeMissingDev})
+        results = check.extra(pkg, deps, {
+          excludeDev: options.excludeUnusedDev || options.excludeMissingDev,
+          ignore: options.ignoreUnused
+        })
         if (results.length !== 0) {
           grunt.log.error('Modules in package.json not used in code: ' + grunt.log.wordlist(results, {color: 'red'}))
         }


### PR DESCRIPTION
Some modules, like [pg](https://npmjs.org/package/pg) when used with [knex](https://www.npmjs.com/package/knex), will look like they are missing because they are not required from the module directly, but rather indirectly through another module.

I'm adding a new option to enable ignoring such modules specifically so that one only gets warned about unused modules that one haven't flagged as a false positive.

While adding this option I also realized I had gotten the name of one of the options in the grunt task wrong (refered to _missing_ when it should have refered to _unused_), so I fixed it while maintaining backwards compatibility.

@maxogden: Not sure if you rather would have me go ahead and push this myself or if you rather have the chance of looking through it first – would you rather have me open PR:s like this or just go ahead and commit small features like this?