### PR TITLE
Add option to skip checking default entries

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -17,12 +17,17 @@ if (args.help || args._.length === 0) {
   console.log('--unused, --extra     The inverse of the --missing check and will tell you which modules in your package.json *were not* used in your code')
   console.log('--no-dev              Won\'t tell you about which devDependencies in your package.json dependencies that were not used in your code. Only usable with --unused')
   console.log('--entry               By default your main and bin entries from package.json will be parsed, but you can add more the list of entries by passing them in as --entry')
+  console.log('--no-default-entries  Won\'t parse your main and bin entries from package.json will be parsed')
   console.log("")
 
   process.exit(1)
 }
 
-check({path: args._[0], entries: args.entry}, function(err, data) {
+check({
+  path: args._[0],
+  entries: args.entry,
+  noDefaultEntries: args['default-entries'] === false
+}, function(err, data) {
   if (err) {
     console.error(err.message)
     return process.exit(1)

--- a/index.js
+++ b/index.js
@@ -13,11 +13,11 @@ module.exports = function(opts, cb) {
     if (err && err.code === 'EISDIR') {
       pkgPath = path.join(pkgPath, 'package.json')
       return readPackage(pkgPath, function(err, pkg) {
-      if (err) return cb(err)
-        parse({path: pkgPath, package: pkg, entries: opts.entries}, cb)
+        if (err) return cb(err)
+        parse({path: pkgPath, package: pkg, entries: opts.entries, noDefaultEntries: opts.noDefaultEntries}, cb)
       })
     }
-    parse({path: pkgPath, package: pkg, entries: opts.entries}, cb)
+    parse({path: pkgPath, package: pkg, entries: opts.entries, noDefaultEntries: opts.noDefaultEntries}, cb)
   })
 }
 
@@ -60,9 +60,9 @@ function parse(opts, cb) {
   var paths = []
   var seen = []
   var mainPath = path.resolve(pkg.main || path.join(path.dirname(pkgPath), 'index.js'))
-  if (fs.existsSync(mainPath)) paths.push(mainPath)
+  if (!opts.noDefaultEntries && fs.existsSync(mainPath)) paths.push(mainPath)
   
-  if (pkg.bin) {
+  if (!opts.noDefaultEntries && pkg.bin) {
     if (typeof pkg.bin === 'string') {
       paths.push(path.resolve(path.join(path.dirname(pkgPath), pkg.bin)))
     } else {

--- a/tasks/dependency-check.js
+++ b/tasks/dependency-check.js
@@ -11,7 +11,11 @@ module.exports = function (grunt) {
       package: '.'
     })
 
-    check({path: options.package, entries: this.filesSrc}, function(err, data) {
+    check({
+      path: options.package,
+      entries: this.filesSrc,
+      noDefaultEntries: true
+    }, function(err, data) {
       if (err) {
         return grunt.fail.fatal(err)
       }


### PR DESCRIPTION
This especially makes the Grunt task behave more as one would expect. Usually Grunt tasks only checks the files that have been explicitly specified that it should check, so the previous behavior of always also checking the main and the bin files caused some unexpected behavior in that scenario.

Also a generally useful option in the CLI as well, if one for some reason wants to check a specific files for missing modules.

@maxogden: As with https://github.com/maxogden/dependency-check/pull/23, not sure if you prefer for me to just go ahead and add this or if you prefer to give it a quick review first?