### PR TITLE
Allow files to be manipualted by a command line before analysis

### DIFF
--- a/LOUD-test/index.js
+++ b/LOUD-test/index.js
@@ -1,0 +1,1 @@
+require('./test.LS')

--- a/LOUD-test/package.json
+++ b/LOUD-test/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test",
+  "version": "0.0.1",
+  "dependencies": {
+  	"uppercase": "*",
+  	"lowercase": "*"
+  }
+}

--- a/LOUD-test/test.LS
+++ b/LOUD-test/test.LS
@@ -1,0 +1,8 @@
+/* This is an example using 'LOUDscript', which is translated
+ * into JavaScript using the command: 'tr A-Z a-z'.
+ *
+ * It requires 2 files: "uppercase" and "lowercase"
+ */
+
+REQUIRE("UpperCase")
+require("LowerCase")

--- a/cli.js
+++ b/cli.js
@@ -31,7 +31,7 @@ check({
   path: args._[0],
   entries: args.entry,
   noDefaultEntries: args['default-entries'] === false,
-  transformer:args.transformer
+  transformer: args.transformer
 }, function (err, data) {
   if (err) {
     console.error(err.message)

--- a/cli.js
+++ b/cli.js
@@ -21,6 +21,7 @@ if (args.help || args._.length === 0) {
   console.log("--no-default-entries  Won't parse your main and bin entries from package.json will be parsed")
   console.log('--version             Show current version')
   console.log('--ignore              To always exit with code 0 pass --ignore')
+  console.log('--transformer=<cmd>   Transform each file with the program "cmd". The current filename is available as $$')
   console.log('')
 
   process.exit(1)
@@ -29,7 +30,8 @@ if (args.help || args._.length === 0) {
 check({
   path: args._[0],
   entries: args.entry,
-  noDefaultEntries: args['default-entries'] === false
+  noDefaultEntries: args['default-entries'] === false,
+  transformer:args.transformer
 }, function (err, data) {
   if (err) {
     console.error(err.message)

--- a/index.js
+++ b/index.js
@@ -125,7 +125,6 @@ function parse (opts, cb) {
     if (opts.transformer) {
     	var cmd = opts.transformer.split(" ") ; 
     	var args = cmd.slice(1).map(function(a){ return a=="$$"?file:a }) ;
-    	console.log(cmd[0],args);
     	var p = require('child_process').spawn(cmd[0],args) ;
     	var output = "" ;
     	p.stdout.on('data',function(data){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-check",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "checks which modules you have used in your code and then makes sure they are listed as dependencies in your package.json",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dependency-check": "cli.js"
   },
   "scripts": {
-    "test": "standard && node cli.js test/"
+    "test": "standard && node cli.js test/ && ./cli.js --transformer='tr A-Z a-z <$$' LOUD-test/"
   },
   "author": "max ogden",
   "dependencies": {

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,12 @@ in the above example `tests.js` will get added to the entries that get parsed + 
 
 running `dependency-check package.json --no-default-entries --entry tests.js` won't parse any entries other than `tests.js`.  None of the entries from your package.json `main` and `bin` will be parsed
 
+### --transformer=`command-line`
+
+runs the specified command line before checking each file, so that you can run any transpilers, such as nodent, coffeescript, babel, etc. and check their dependencies. With the command line, the special sequence `$$` is replaced with the full path of the current file being analysed. For example to change every file to lower-case before analysis, use
+
+	dependency-check --transformer='tr A-Z a-z < $$'
+
 ### --help
 
 shows above options and all other available options


### PR DESCRIPTION
Useful to me, so I can run a transpiler (e.g. nodent, babel, maybe type-script, etc?) on each source file, greatly increasing the chances of acorn correctly parsing and finding require() calls.