### PR TITLE
Support adding additional entries through cli glob

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -10,7 +10,7 @@ if (args.version) {
 }
 
 if (args.help || args._.length === 0) {
-  console.log('\nUsage: dependency-check <path to package.json or module folder> <options>')
+  console.log('\nUsage: dependency-check <path to package.json or module folder> <additional entries to add> <options>')
 
   console.log('\nOptions:')
   console.log('--missing (default)   Check to make sure that all modules in your code are listed in your package.json')
@@ -27,8 +27,8 @@ if (args.help || args._.length === 0) {
 }
 
 check({
-  path: args._[0],
-  entries: args.entry,
+  path: args._.shift(),
+  entries: args._.concat(args.entry || []),
   noDefaultEntries: args['default-entries'] === false
 }, function (err, data) {
   if (err) {

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,12 @@ dependency-check package.json --entry tests.js
 
 in the above example `tests.js` will get added to the entries that get parsed + checked in addition to the defaults. You can specify as many separate `--entry` arguments as you want
 
+you can also instead add additional entries directly after your package definition, like:
+
+```
+dependency-check package.json tests.js
+```
+
 ### --no-default-entries
 
 running `dependency-check package.json --no-default-entries --entry tests.js` won't parse any entries other than `tests.js`.  None of the entries from your package.json `main` and `bin` will be parsed
@@ -124,4 +130,3 @@ then configure a task or sub-task, example values are the defaults:
 
 - [detective](https://www.npmjs.org/package/detective) is used for parsing `require()` statements, which means it only does **static requires**. this means you should convert things like `var foo = "bar"; require(foo)` to be static, e.g. `require("bar")`
 - you can specify as many entry points as you like with multiple `--entry foo.js` arguments
-


### PR DESCRIPTION
This PR would enable adding additional entries by utilizing the built in glob support that's often available when running a command from the terminal. One could do something like:

```bash
dependency-check . test/**/*.spec.js
```

As eg. tests are rarely referenced from anywhere it can be hard to auto-discover the files and there might also be quite a few test files in a project so adding them all manually as `--entry` isn't really feasible either.

There is a slight backwards compatibility risk with this as before additional non-option arguments has just been discarded while now they would be added as additional entries.

The API also becomes a bit weird where both additional entries and the package.json will be specified in the same way, but additional entries can only be added of an explicit package.json has been defined, which isn't ideal.

If one could specify any number of js-files and/or package.json files in any order then the API would be better, but that would likely require a bit of refactoring to support and for most use cases this will work at least.

Ping @maxogden: Got any opinion or thoughts on this change?