### PR TITLE
Add support for --extensions and --detective

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -12,7 +12,8 @@ var args = require('minimist')(process.argv.slice(2), {
   boolean: ['missing', 'extra', 'dev', 'version', 'ignore', 'default-entries'],
   alias: {
     extra: 'unused',
-    'ignore-module': 'i'
+    'ignore-module': 'i',
+    'extensions': 'e'
   }
 })
 
@@ -31,6 +32,8 @@ if (args.help || args._.length === 0) {
   console.log("--ignore-module, -i   Won't tell you about module names passed in as --ignore-module / -i. Only usable with --unused")
   console.log('--entry               By default your main and bin entries from package.json will be parsed, but you can add more the list of entries by passing them in as --entry')
   console.log("--no-default-entries  Won't parse your main and bin entries from package.json will be parsed")
+  console.log('--detective           Pointing to a requireable path of a javascript file containing an alternative implementation of the detective module that supports extended or alternate syntaxes')
+  console.log("--extensions, -e      Comma-separated list of file extensions to use when resolving require paths. Eg. 'js,jsx'")
   console.log('--version             Show current version')
   console.log('--ignore              To always exit with code 0 pass --ignore')
   console.log('')
@@ -38,10 +41,21 @@ if (args.help || args._.length === 0) {
   process.exit(1)
 }
 
+var extensions
+
+if (args.e) {
+  extensions = args.e.split(',').map(function (item) {
+    item = item.trim()
+    return item[0] === '.' ? item : '.' + item
+  })
+}
+
 check({
   path: args._.shift(),
   entries: args._.concat(args.entry || []),
-  noDefaultEntries: !args['default-entries']
+  noDefaultEntries: !args['default-entries'],
+  extensions: extensions,
+  detective: args.detective
 }, function (err, data) {
   if (err) {
     console.error(err.message)

--- a/cli.js
+++ b/cli.js
@@ -41,10 +41,10 @@ if (args.help || args._.length === 0) {
   process.exit(1)
 }
 
-var extensions
+var splitArg = function (arg) {
+  if (!arg) return undefined
 
-if (args.e) {
-  extensions = args.e.split(',').map(function (item) {
+  return (typeof arg === 'string' ? arg.split(',') : arg).map(function (item) {
     item = item.trim()
     return item[0] === '.' ? item : '.' + item
   })
@@ -54,7 +54,7 @@ check({
   path: args._.shift(),
   entries: args._.concat(args.entry || []),
   noDefaultEntries: !args['default-entries'],
-  extensions: extensions,
+  extensions: splitArg(args.e),
   detective: args.detective
 }, function (err, data) {
   if (err) {

--- a/index.js
+++ b/index.js
@@ -92,15 +92,15 @@ function parse (opts, cb) {
   var pkg = opts.package
 
   var extensions = opts.extensions
-  var configuredDetective
+  var detective
 
   try {
-    configuredDetective = opts.detective
+    detective = opts.detective
       ? (typeof opts.detective === 'string' ? require(opts.detective) : opts.detective)
       : require('detective')
   } catch (e) {}
 
-  if (!configuredDetective || typeof configuredDetective !== 'function') return cb(new Error('Found no valid detective function'))
+  if (!detective || typeof detective !== 'function') return cb(new Error('Found no valid detective function'))
 
   var paths = []
   var seen = []
@@ -168,7 +168,7 @@ function parse (opts, cb) {
         return callback(err)
       }
 
-      var requires = configuredDetective(contents)
+      var requires = detective(contents)
       var relatives = []
       requires.map(function (req) {
         var isCore = builtins.indexOf(req) > -1

--- a/index.js
+++ b/index.js
@@ -22,10 +22,26 @@ module.exports = function (opts, cb) {
       pkgPath = path.join(pkgPath, 'package.json')
       return readPackage(pkgPath, function (err, pkg) {
         if (err) return cb(err)
-        parse(Object.assign({path: pkgPath, package: pkg}, baseOpts), cb)
+        parse({
+          path: pkgPath,
+          package: pkg,
+          entries: opts.entries,
+          noDefaultEntries: opts.noDefaultEntries,
+          builtins: opts.builtins,
+          extensions: opts.extensions,
+          detective: opts.detective
+        }, cb)
       })
     }
-    parse(Object.assign({path: pkgPath, package: pkg}, baseOpts), cb)
+    parse({
+      path: pkgPath,
+      package: pkg,
+      entries: opts.entries,
+      noDefaultEntries: opts.noDefaultEntries,
+      builtins: opts.builtins,
+      extensions: opts.extensions,
+      detective: opts.detective
+    }, cb)
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var path = require('path')
 var fs = require('fs')
 var readPackage = require('read-package-json')
-var detective = require('detective')
 var async = require('async')
 var builtins = require('builtins')
 var resolve = require('resolve')
@@ -93,9 +92,13 @@ function parse (opts, cb) {
   var pkg = opts.package
 
   var extensions = opts.extensions
-  var configuredDetective = opts.detective
-    ? (typeof opts.detective === 'string' ? require(opts.detective) : opts.detective)
-    : detective
+  var configuredDetective
+
+  try {
+    configuredDetective = opts.detective
+      ? (typeof opts.detective === 'string' ? require(opts.detective) : opts.detective)
+      : require('detective')
+  } catch (e) {}
 
   if (!configuredDetective || typeof configuredDetective !== 'function') return cb(new Error('Found no valid detective function'))
 

--- a/index.js
+++ b/index.js
@@ -11,13 +11,6 @@ var isRelative = require('is-relative')
 module.exports = function (opts, cb) {
   var pkgPath = opts.path
   readPackage(pkgPath, function (err, pkg) {
-    var baseOpts = {
-      entries: opts.entries,
-      noDefaultEntries: opts.noDefaultEntries,
-      builtins: opts.builtins,
-      extensions: opts.extensions,
-      detective: opts.detective
-    }
     if (err && err.code === 'EISDIR') {
       pkgPath = path.join(pkgPath, 'package.json')
       return readPackage(pkgPath, function (err, pkg) {

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,14 @@ dependency-check package.json tests.js
 
 running `dependency-check package.json --no-default-entries --entry tests.js` won't parse any entries other than `tests.js`.  None of the entries from your package.json `main` and `bin` will be parsed
 
+### --extensions, -e
+
+running `dependency-check ./package.json -e js,jsx` will resolve extensionless require paths to both `.js` and `.jsx` paths. Defaults to just `.js`
+
+### --detective
+
+running `dependency-check ./package.json  --detective precinct` will `require()` the local path `precinct` which will load the [precinct](https://www.npmjs.com/package/precinct) module if that has been installed. The loaded module will then be used instead of the default [detective](https://www.npmjs.com/package/detective) module when looking up all required modules.
+
 ### --help
 
 shows above options and all other available options


### PR DESCRIPTION
Eg. enables dependency-check to work on a full React JSX project by installing "precinct" and running:

```bash
dependency-check . --detective precinct -e js,jsx
```

Fixes #60