### PR TITLE
Pin read-package-json to 2.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "detective": "^4.0.0",
     "is-relative": "^0.2.1",
     "minimist": "^1.2.0",
-    "read-package-json": "^2.0.4",
+    "read-package-json": "2.0.6",
     "resolve": "^1.1.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Works around npm/read-package-json#71. Maybe wait a couple days before merging to see if that's resolved?