### PR TITLE
Add a quiet  mode to the CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -10,7 +10,7 @@ const args = require('minimist')(process.argv.slice(2), {
     extra: false,
     dev: true,
     'default-entries': true,
-    quiet: false,
+    quiet: false
   },
   boolean: ['missing', 'extra', 'dev', 'version', 'ignore', 'default-entries', 'quiet'],
   alias: {

--- a/cli.js
+++ b/cli.js
@@ -9,9 +9,10 @@ const args = require('minimist')(process.argv.slice(2), {
     missing: false,
     extra: false,
     dev: true,
-    'default-entries': true
+    'default-entries': true,
+    quiet: false,
   },
-  boolean: ['missing', 'extra', 'dev', 'version', 'ignore', 'default-entries'],
+  boolean: ['missing', 'extra', 'dev', 'version', 'ignore', 'default-entries', 'quiet'],
   alias: {
     extra: 'unused',
     'ignore-module': 'i',
@@ -39,6 +40,7 @@ if (args.help || args._.length === 0) {
   console.log("--extensions, -e      List of file extensions with detective to use when resolving require paths. Eg. 'js,jsx:detective-es6'")
   console.log('--version             Show current version')
   console.log('--ignore              To always exit with code 0 pass --ignore')
+  console.log('--quiet               To disable logging on success')
   console.log('')
 
   process.exit(1)
@@ -86,7 +88,7 @@ check({
       failed += extras.length
       if (extras.length) {
         console.error('Fail! Modules in package.json not used in code: ' + extras.join(', '))
-      } else {
+      } else if (!args.quiet) {
         console.log('Success! All dependencies in package.json are used in the code')
       }
     }
@@ -95,7 +97,7 @@ check({
       failed += missing.length
       if (missing.length) {
         console.error('Fail! Dependencies not listed in package.json: ' + missing.join(', '))
-      } else {
+      } else if (!args.quiet) {
         console.log('Success! All dependencies used in the code are listed in package.json')
       }
     }

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,10 @@ running `dependency-check ./package.json -e js,jsx:precinct` will resolve requir
 
 running `dependency-check ./package.json --detective precinct` will `require()` the local `precinct` as the default parser. This can be set per-extension using using `-e`. Defaults to parsing with [`detective`](https://www.npmjs.com/package/detective).
 
+### --quiet
+
+Running with `--quiet` will diable the default log message on success, so that dependency-check only logs on failure.
+
 ### --help
 
 shows above options and all other available options


### PR DESCRIPTION
I'm using this on many packages with lerna and it's hard to spot the "Fail" messages amongst all the "Success" messages.  It would be a lot easier if this module didn't log anything on success.