### PR TITLE
Resolve entry globs internally

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const builtins = require('builtins')()
 const resolveModule = require('resolve')
 const debug = require('debug')('dependency-check')
 const isRelative = require('is-relative')
+const globby = require('globby')
 
 const promisedReadPackage = function (pkgPath) {
   return new Promise((resolve, reject) => {
@@ -164,10 +165,17 @@ function parse (opts) {
   // pass in custom additional entries e.g. ['./test.js']
   if (opts.entries) {
     if (typeof opts.entries === 'string') opts.entries = [opts.entries]
-    opts.entries.forEach(entry => {
-      entry = path.resolve(path.join(path.dirname(pkgPath), entry))
-      if (paths.indexOf(entry) === -1) {
-        paths.push(entry)
+
+    globby.sync(opts.entries, {
+      cwd: path.dirname(pkgPath),
+      absolute: true,
+      expandDirectories: false
+    }).forEach(entry => {
+      // Globby yields unix-style paths.
+      const normalized = path.resolve(entry)
+
+      if (paths.indexOf(normalized) === -1) {
+        paths.push(normalized)
       }
     })
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "builtins": "^2.0.0",
     "debug": "^3.1.0",
     "detective": "^5.0.2",
+    "globby": "^8.0.1",
     "is-relative": "^1.0.0",
     "minimist": "^1.2.0",
     "read-package-json": "^2.0.10",


### PR DESCRIPTION
Closes #84.

I picked `globby` because it exports an Promise API, but this PR uses `globby.sync`. A next step would be to resolve globs asynchronously. I did not feel comfortable doing so, with my limited knowledge of this codebase.