### PR TITLE
Silently pass on unsupported versions of Node.js

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,6 +2,11 @@
 
 'use strict'
 
+if (process.version.match(/^v(\d+)\./)[1] < 6) {
+  console.error('dependency-check: Node 6 or greater is required. `dependency-check` did not run.')
+  process.exit(0)
+}
+
 const check = require('./')
 
 const args = require('minimist')(process.argv.slice(2), {


### PR DESCRIPTION
While Node.js <6 haven't been officially supported by `dependency-check` since version 3, it did technically work until v3.2.1 was released as the `debug` dependency now uses the `let` keyword and therefore fails when being required.

This PR allows users to have `depedency-check` v3 as part of their CI build pipeline without being required to remove EoL versions of Node.js from their build matrix.

This escape hatch is similar to the one used in the [standard linter](https://github.com/standard/standard/commit/9ee4d0f24cdf6a39def467b88e8504c28be15cfd).